### PR TITLE
Fix DirectoryNotFoundException

### DIFF
--- a/OW360Camera/OW360Camera.cs
+++ b/OW360Camera/OW360Camera.cs
@@ -106,7 +106,10 @@ namespace OW360Camera
             equirect.Release();
 
             byte[] bytes = screenshot.EncodeToPNG();
-            string path = ModHelper.Config.GetSettingsValue<string>("SavePath") + DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss") + ".png";
+            string directory = ModHelper.Config.GetSettingsValue<string>("SavePath");
+            string path = directory + DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss") + ".png";
+            if (!Directory.Exists(directory))
+                Directory.CreateDirectory(directory);
             File.WriteAllBytes(path, bytes);
             
             ModHelper.Console.WriteLine("Saved ScreenShot to " + path, MessageType.Success);

--- a/OW360Camera/manifest.json
+++ b/OW360Camera/manifest.json
@@ -3,6 +3,6 @@
   "author": "BUNN1E5",
   "name": "360 Camera",
   "uniqueName": "BUNN1E5.OW360Camera",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "owmlVersion": "2.3.2"
 }


### PR DESCRIPTION
I got this exception when using the mod. So I fixed it.
```csharp
DirectoryNotFoundException: Could not find a part of the path "C:\Program Files\Epic Games\OuterWilds\Pictures\2022-04-22-23-28-43.png".
Stacktrace: System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.Boolean anonymous, System.IO.FileOptions options) (at <eae584ce26bc40229c1b1aa476bfa589>:0)
System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize) (at <eae584ce26bc40229c1b1aa476bfa589>:0)
System.IO.File.Create (System.String path, System.Int32 bufferSize) (at <eae584ce26bc40229c1b1aa476bfa589>:0)
System.IO.File.Create (System.String path) (at <eae584ce26bc40229c1b1aa476bfa589>:0)
System.IO.File.WriteAllBytes (System.String path, System.Byte[] bytes) (at <eae584ce26bc40229c1b1aa476bfa589>:0)
OW360Camera.OW360Camera.ScreenShot () (at <c64548f4c5bc4d5f905bc660d53d7c3a>:0)
OW360Camera.OW360Camera.Update () (at <c64548f4c5bc4d5f905bc660d53d7c3a>:0)
```